### PR TITLE
[Fix] Operation not permitted on postgresql docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Ensure you have the following installed:
 
 3. Run PostgreSQL Local:
    ```bash
-   mkdir data
    docker-compose up -d
    ```
 


### PR DESCRIPTION
## Background
if we run `mkdir data` before docker compose up, postgresql will find permissions error

<img width="598" alt="Screenshot 2568-07-01 at 11 21 56" src="https://github.com/user-attachments/assets/ec30a3d4-20c2-4760-aa00-06e57153ee11" />

## Solution
Let docker-compose.yaml create folder data
https://github.com/fastworkco/swe-interview/blob/main/docker-compose.yaml#L15